### PR TITLE
use thread.join() to wait for all threads to finish in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,22 @@ A python module aimed to wrap [twitch.tvs custom IRC implementation](https://git
 # Usage
 ```python
 from twitchchat import twitch_chat
-
-from twitchchat import twitch_chat
-from time import sleep
 import logging
 
 
 def new_message(msg):
-    print msg
+    print(msg)
 
 
 def new_subscriber(name, months):
-    print 'New subscriber {0}! For {1} months'.format(name, months)
+    print('New subscriber {0}! For {1} months'.format(name, months))
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
 tirc = twitch_chat('animaggus', 'yourtwitchoauth', ['geekandsundry', 'riotgames'])
 tirc.subscribeChatMessage(new_message)
 tirc.subscribeNewSubscriber(new_subscriber)
 tirc.start()
-while True:
-    sleep(0.2)
+tirc.join()
 ```
 
 #Future

--- a/twitchchat/chat.py
+++ b/twitchchat/chat.py
@@ -46,6 +46,10 @@ class twitch_chat(object):
         for handler in self.irc_handlers:
             handler.start()
 
+    def join(self):
+        for handler in self.irc_handlers:
+            handler.asynloop_thread.join()
+
     def stop(self):
         for handler in self.irc_handlers:
             handler.stop()


### PR DESCRIPTION
Use `thread.join()` to wait for all threads to finish instead of `sleep()`-loop in example. It's only a minor thing but I think its cleaner this way.
